### PR TITLE
Add compatibility for sshuttle > 1.05

### DIFF
--- a/gateway_jumper
+++ b/gateway_jumper
@@ -98,7 +98,7 @@ if { "x${dest_pass}" != "x" } {
         "?assword:" {
             send -- "${dest_pass}\r"
         }
-        "client: Connected." { err_print "Expected password prompt on destination host but got connected; aborting for safety" }
+        -re "(c :|client:) Connected" { err_print "Expected password prompt on destination host but got connected; aborting for safety" }
     }
 }
 
@@ -117,7 +117,7 @@ expect {
     "?assword:" {
         err_print "Unexpected password prompt; most likely reason is that the TOTP code '${otp}' was not accepted"
     }
-    "client: Connected."
+    -re "(c :|client:) Connected"
 }
 
 # We cannot just exit this script, since any spawned process will be killed


### PR DESCRIPTION
In https://github.com/sshuttle/sshuttle/commit/7cb30b783db0be35beb227a0fdeffaa554eaa05a sshuttle made the prefixes more consistent, removing the "client: Connected" prefix when sshuttle connects. 

In newer versions it prints "c : Connected to server.", which this PR adds support for.