### PR TITLE
Fix glob matching for jumphost

### DIFF
--- a/gateway_jumper
+++ b/gateway_jumper
@@ -52,7 +52,7 @@ expect {
         if { "x${local_pass}" == "x" } { err_print "Local sudo password needed but not given" }
         send -- "${local_pass}\r"
     }
-    "^?assword:" {
+    "?assword:" {
         send -- "${jump_pass}\r"
     }
 }


### PR DESCRIPTION
For some reason `"^?assword:"` matches neither `password` nor `Password` (on macos Big Sur at least). This commit fixes that by relaxing the glob match.